### PR TITLE
Fix aura Global-panel config, anchor persistence, sequential preview; mask icons

### DIFF
--- a/modules/auras.lua
+++ b/modules/auras.lua
@@ -484,6 +484,14 @@ local function updateButton(id, group, config)
 		button.icon = button:CreateTexture(nil, "BACKGROUND")
 		button.icon:SetAllPoints(button)
 		button.icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
+
+		-- Mask the icon artwork to rounded corners so it doesn't poke past the border.
+		-- The atlas has transparent padding, so the mask is oversized (size set below) and
+		-- centered, otherwise the artwork gets clipped well inside the frame.
+		button.iconMask = button:CreateMaskTexture(nil, "BACKGROUND")
+		button.iconMask:SetPoint("CENTER", button, "CENTER", 0, 0)
+		button.iconMask:SetAtlas("UI-HUD-ActionBar-IconFrame-Mask", false)
+		button.icon:AddMaskTexture(button.iconMask)
 	end
 
 	if( ShadowUF.db.profile.auras.borderType == "" ) then
@@ -507,6 +515,8 @@ local function updateButton(id, group, config)
 	button:SetWidth(config.size)
 	button.border:SetHeight(config.size + 1)
 	button.border:SetWidth(config.size + 1)
+	local maskSize = math.floor((config.size * 1.5) + 0.5)
+	button.iconMask:SetSize(maskSize, maskSize)
 	ShadowUF:SetFontAndShadow(button.stack, "Interface\\AddOns\\ShadowedUnitFrames\\media\\fonts\\Myriad Condensed Web.ttf", math.floor((config.size * 0.60) + 0.5), "OUTLINE", 0, 0, 0, 1.0, 0.50, -0.50)
 
 	-- Click-through: disable mouse clicks but keep mouse motion (tooltips)
@@ -657,9 +667,9 @@ function Auras:OnLayoutApplied(frame, config)
 		local buffsGroup = frame.auras["buffs" .. i]
 		local debuffsGroup = frame.auras["debuffs" .. i]
 
-		-- Clear skipScan on both groups (may have been set by a previous layout)
-		if( buffsGroup ) then buffsGroup.skipScan = nil end
-		if( debuffsGroup ) then debuffsGroup.skipScan = nil end
+		-- Clear skipScan and forced anchor overrides on both groups (may have been set by a previous layout)
+		if( buffsGroup ) then buffsGroup.skipScan = nil; buffsGroup.forcedAnchorPoint = nil; buffsGroup.forcedGrowH = nil; buffsGroup.forcedGrowV = nil end
+		if( debuffsGroup ) then debuffsGroup.skipScan = nil; debuffsGroup.forcedAnchorPoint = nil; debuffsGroup.forcedGrowH = nil; debuffsGroup.forcedGrowV = nil end
 
 		if( buffsConfig and buffsConfig.enabled and debuffsConfig and debuffsConfig.enabled and buffsGroup and debuffsGroup ) then
 			local anchorOnConfig, parentGroup, childGroup, parentConfig, childConfig
@@ -1126,17 +1136,20 @@ end
 
 -- 12.0: categorizeAura function removed - filtering is now done via API filters directly
 
+-- The frame config that drives button layout: always the group's OWN frame config, so that
+-- sequentially-appended child auras flow using the parent's layout instead of their own.
+local function getLayoutConfig(frame, fallback)
+	local unitConfig = ShadowUF.db.profile.units[frame.parent.unitType]
+	local auraConfig = unitConfig and unitConfig.auras[frame.type]
+	return (auraConfig and auraConfig[frame.frameIndex or 1]) or fallback
+end
+
 local function renderAura(parent, frame, type, config, displayConfig, index, filter, isFriendly, curable, name, texture, count, auraType, durationObject, caster, isRemovable, nameplateShowPersonal, spellID, canApplyAura, isPlayerAura, auraInstanceID)
 
 	-- Create any buttons we need
 	frame.totalAuras = frame.totalAuras + 1
 	if( #(frame.buttons) < frame.totalAuras ) then
-		-- Get the correct config for this frame
-		local unitConfig = ShadowUF.db.profile.units[frame.parent.unitType]
-		local auraConfig = unitConfig.auras[frame.type]
-		local frameIndex = frame.frameIndex or 1
-		local frameConfig = auraConfig and auraConfig[frameIndex] or config
-		updateButton(frame.totalAuras, frame, frameConfig)
+		updateButton(frame.totalAuras, frame, getLayoutConfig(frame, config))
 	end
 
 	-- Show debuff border, or a special colored border if it's stealable
@@ -1205,7 +1218,15 @@ end
 local function scanConfigMode(parent, frame, type, config, displayConfig, filter)
 	local testCount = config.perRow * config.maxRows
 	local isBuff = (type == "buffs")
-	
+
+	-- Preview aid: when this group is the parent of a sequential pair, leave the last row
+	-- partly empty so the appended child auras visibly continue the same queue. A full grid
+	-- always wraps to a new row, making sequential look identical to "new row" mode.
+	local pair = frame.parent.auras and frame.parent.auras.anchorPairs and frame.parent.auras.anchorPairs[frame.frameIndex or 0]
+	if( pair and pair.sequential and pair.parent == frame and type == frame.type ) then
+		testCount = math.max(1, testCount - math.floor(config.perRow / 2))
+	end
+
 	for i = 1, testCount do
 		local mod = i % 5
 		local auraType = mod == 0 and "Magic" or mod == 1 and "Curse" or mod == 2 and "Poison" or mod == 3 and "Disease" or ""
@@ -1222,11 +1243,11 @@ local function scanConfigMode(parent, frame, type, config, displayConfig, filter
 		-- Create any buttons we need
 		frame.totalAuras = frame.totalAuras + 1
 		if( #(frame.buttons) < frame.totalAuras ) then
-			updateButton(frame.totalAuras, frame, config)
+			updateButton(frame.totalAuras, frame, getLayoutConfig(frame, config))
 		end
-		
+
 		local button = frame.buttons[frame.totalAuras]
-		
+
 		-- Set border color based on aura type
 		if( isRemovable and not isBuff and not config.disableRemovableColor ) then
 			button.border:SetVertexColor(ShadowUF.db.profile.auraColors.removable.r, ShadowUF.db.profile.auraColors.removable.g, ShadowUF.db.profile.auraColors.removable.b)

--- a/options/config.lua
+++ b/options/config.lua
@@ -2355,19 +2355,32 @@ local function loadUnitOptions()
 
 	-- Helper to get frame config (auras.buffs[1], auras.debuffs[2], etc.)
 	local function getAuraFrameConfig(unit, auraType, frameIndex)
-		local config = ShadowUF.db.profile.units[unit]
+		local config = unit == "global" and globalConfig or ShadowUF.db.profile.units[unit]
 		if config and config.auras and config.auras[auraType] and config.auras[auraType][frameIndex] then
 			return config.auras[auraType][frameIndex]
 		end
 		return nil
 	end
 
-	local function setAuraFrameValue(unit, auraType, frameIndex, key, value)
-		local config = ShadowUF.db.profile.units[unit]
-		if config and config.auras and config.auras[auraType] and config.auras[auraType][frameIndex] then
-			config.auras[auraType][frameIndex][key] = value
-			reloadUnitAuras()
+	-- Apply mutator(frameConfig) to one unit's aura frame, fanning out across the
+	-- globally-selected units (+ the globalConfig mirror) when unit == "global".
+	local function modifyAuraFrame(unit, auraType, frameIndex, mutator)
+		local function apply(u)
+			local fc = getAuraFrameConfig(u, auraType, frameIndex)
+			if( fc ) then mutator(fc) end
 		end
+
+		if( unit == "global" ) then
+			for modUnit in pairs(modifyUnits) do apply(modUnit) end
+			apply("global")
+		else
+			apply(unit)
+		end
+		reloadUnitAuras()
+	end
+
+	local function setAuraFrameValue(unit, auraType, frameIndex, key, value)
+		modifyAuraFrame(unit, auraType, frameIndex, function(fc) fc[key] = value end)
 	end
 
 	-- Create options for a single aura frame slot
@@ -2576,14 +2589,11 @@ local function loadUnitOptions()
 					end,
 					set = function(info, value)
 						local auraType = info[#(info) - 2]
-						-- Disable enlarge.PLAYER when switching to PLAYER filter
-						if value == "PLAYER" then
-							local cfg = getAuraFrameConfig(info[2], auraType, frameIndex)
-							if cfg and cfg.enlarge then
-								cfg.enlarge.PLAYER = false
-							end
-						end
-						setAuraFrameValue(info[2], auraType, frameIndex, "filter", value)
+						modifyAuraFrame(info[2], auraType, frameIndex, function(fc)
+							-- Disable enlarge.PLAYER when switching to PLAYER filter
+							if( value == "PLAYER" and fc.enlarge ) then fc.enlarge.PLAYER = false end
+							fc.filter = value
+						end)
 					end,
 					disabled = function(info)
 						local auraType = info[#(info) - 2]
@@ -2874,11 +2884,9 @@ local function loadUnitOptions()
 					end,
 					set = function(info, r, g, b, a)
 						local auraType = info[#(info) - 2]
-						local config = ShadowUF.db.profile.units[info[2]]
-						if config and config.auras and config.auras[auraType] and config.auras[auraType][frameIndex] then
-							config.auras[auraType][frameIndex].cooldownFontColor = {r = r, g = g, b = b, a = a}
-							reloadUnitAuras()
-						end
+						modifyAuraFrame(info[2], auraType, frameIndex, function(fc)
+							fc.cooldownFontColor = {r = r, g = g, b = b, a = a}
+						end)
 					end,
 					disabled = function(info)
 						local auraType = info[#(info) - 2]
@@ -2904,12 +2912,10 @@ local function loadUnitOptions()
 					end,
 					set = function(info, value)
 						local auraType = info[#(info) - 2]
-						local config = ShadowUF.db.profile.units[info[2]]
-						if config and config.auras and config.auras[auraType] and config.auras[auraType][frameIndex] then
-							config.auras[auraType][frameIndex].enlarge = config.auras[auraType][frameIndex].enlarge or {}
-							config.auras[auraType][frameIndex].enlarge.PLAYER = value
-							reloadUnitAuras()
-						end
+						modifyAuraFrame(info[2], auraType, frameIndex, function(fc)
+							fc.enlarge = fc.enlarge or {}
+							fc.enlarge.PLAYER = value
+						end)
 					end,
 					disabled = function(info)
 						local auraType = info[#(info) - 2]
@@ -3367,19 +3373,32 @@ local function loadUnitOptions()
 				width = "half",
 				hidden = isModifiersSet,
 				get = function(info)
+					if( info[2] == "global" ) then
+						-- On only when every globally-selected unit is in test mode
+						for modUnit in pairs(modifyUnits) do
+							local cfg = ShadowUF.db.profile.units[modUnit]
+							if( not (cfg and cfg.auras and cfg.auras.testMode) ) then return false end
+						end
+						return next(modifyUnits) ~= nil
+					end
 					local cfg = ShadowUF.db.profile.units[info[2]]
 					return cfg and cfg.auras and cfg.auras.testMode
 				end,
 				set = function(info, value)
-					local unitType = info[2]
-					local cfg = ShadowUF.db.profile.units[unitType]
-					if cfg and cfg.auras then
-						cfg.auras.testMode = value
+					local function apply(unitType)
+						local cfg = ShadowUF.db.profile.units[unitType]
+						if( cfg and cfg.auras ) then cfg.auras.testMode = value end
+						if( value ) then
+							ShadowUF.modules.movers:EnableTestMode(unitType)
+						else
+							ShadowUF.modules.movers:DisableTestMode(unitType)
+						end
 					end
-					if value then
-						ShadowUF.modules.movers:EnableTestMode(unitType)
+
+					if( info[2] == "global" ) then
+						for modUnit in pairs(modifyUnits) do apply(modUnit) end
 					else
-						ShadowUF.modules.movers:DisableTestMode(unitType)
+						apply(info[2])
 					end
 				end,
 			},


### PR DESCRIPTION
Four fixes to the multi-frame aura system. Each is independent; happy to split into separate PRs if you'd prefer.

### 1. Global panel aura settings & Test mode were no-ops
Aura frame options and the Test mode toggle wrote to/read from `units["global"]`, which doesn't exist, so changing them in the Global section did nothing. They now fan out across the globally-selected units (`modifyUnits`) + the `globalConfig` mirror, the same way `setDirectUnit` does for other settings.

### 2. Chosen aura anchor ignored after un-anchoring
`forcedAnchorPoint` / `forcedGrowH` / `forcedGrowV` are stamped on the child group of an `anchorOn` pair but were never cleared. Because frames persist across reloads, once a group had been a child its forced anchor kept overriding the user's chosen `anchorPoint`. Now cleared every layout apply, right alongside `skipScan`.

### 3. Sequential anchor mode preview didn't reflect runtime
- Appended child auras were positioned with the *child's* config instead of the parent group's, so the preview could even grow them the wrong direction. Extracted the layout-config lookup `renderAura` already did into `getLayoutConfig` and used it in `scanConfigMode` too.
- In test/unlock mode each frame fills its full grid, so appended auras always wrapped to a new row — making Sequential look identical to "New row". The parent of a sequential pair now leaves its last row partly empty in preview so the merge is visible.

### 4. Icon artwork poked past the frame border
Aura icons were only zoom-cropped (`SetTexCoord`), with no mask, so the square corners overhung the border. Added a `UI-HUD-ActionBar-IconFrame-Mask` mask texture (oversized + centered to account for the atlas padding) on the icon.

All changes are LF, scoped to `modules/auras.lua` and `options/config.lua`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)