### PR TITLE
Click-to-cancel personal buffs via secure overlay

### DIFF
--- a/ShadowedUnitFrames.toc
+++ b/ShadowedUnitFrames.toc
@@ -81,3 +81,4 @@ modules\priest.lua
 modules\shaman.lua
 modules\arcanecharges.lua
 modules\essence.lua
+modules\auracancel.lua

--- a/modules/auracancel.lua
+++ b/modules/auracancel.lua
@@ -1,0 +1,94 @@
+-- Secure right-click/click cancel for the player's cancelable buffs.
+--
+-- Direct port of JustAC/UI/UIPrecombatOverlay.lua's approach. SUF's aura icons stay INSECURE, so
+-- SUF keeps all its filtering / layout / multi-frame setup and can rebuild the icons every frame
+-- (which a protected frame can't do in combat). A pool of invisible SecureActionButtonTemplate
+-- layers is parked over the cancelable player-buff icons OUT OF COMBAT, each carrying a
+-- /cancelaura macro. The pool lives in a container hidden in combat by a SECURE state driver
+-- ([combat] hide) — taint-free — so we never show/hide secure frames in combat ourselves.
+
+local POOL_SIZE = 40
+local container, layers, eventFrame, scheduled
+
+local function ensurePool()
+	if( container ) then return true end
+	if( InCombatLockdown() ) then return false end
+	container = CreateFrame("Frame", "SUFAuraCancelOverlay", UIParent)
+	-- Secure environment hides every layer in combat — taint-free; SUF's icons revert to normal.
+	RegisterStateDriver(container, "visibility", "[combat] hide; show")
+	layers = {}
+	for i = 1, POOL_SIZE do
+		local b = CreateFrame("Button", "SUFAuraCancelLayer" .. i, container, "SecureActionButtonTemplate")
+		b:RegisterForClicks("AnyDown", "AnyUp") -- fire regardless of the key-down/up cast CVar
+		b:SetFrameStrata("HIGH")
+		-- Forward hover to the icon below so its tooltip still shows through the layer.
+		b:SetScript("OnEnter", function(self)
+			local f = self.icon and self.icon:GetScript("OnEnter")
+			if( f ) then f(self.icon) end
+		end)
+		b:SetScript("OnLeave", function(self)
+			local f = self.icon and self.icon:GetScript("OnLeave")
+			if( f ) then f(self.icon) end
+		end)
+		b:Hide()
+		layers[i] = b
+	end
+	return true
+end
+
+-- Point a layer at a SUF aura icon (out of combat only) with a /cancelaura macro for its buff.
+local function configureLayer(layer, icon, name)
+	layer.icon = icon
+	layer:SetAttribute("type", "macro")
+	layer:SetAttribute("macrotext", "/cancelaura " .. name)
+	layer:ClearAllPoints()
+	layer:SetAllPoints(icon)
+	layer:SetFrameLevel(icon:GetFrameLevel() + 10)
+	layer:Show()
+end
+
+-- Cover every shown, cancelable player-buff icon with a secure layer (out of combat).
+local function refresh()
+	if( InCombatLockdown() or not ensurePool() ) then return end
+	local units = ShadowUF.Units and ShadowUF.Units.unitFrames
+	local pf = units and units.player
+	local placed = 0
+	if( pf and pf.auras ) then
+		for i = 1, 6 do
+			local cfg = ShadowUF.db.profile.units.player.auras.buffs[i]
+			local group = pf.auras["buffs" .. i]
+			if( group and group.buttons and cfg and not cfg.clickThrough ) then
+				for _, icon in ipairs(group.buttons) do
+					if( placed < POOL_SIZE and icon:IsShown() and icon.unit and icon.auraInstanceID
+						and icon.filter and icon.filter:find("HELPFUL") and UnitIsUnit(icon.unit, "player") ) then
+						local data = C_UnitAuras.GetAuraDataByAuraInstanceID("player", icon.auraInstanceID)
+						if( data and data.name ) then
+							placed = placed + 1
+							configureLayer(layers[placed], icon, data.name)
+						end
+					end
+				end
+			end
+		end
+	end
+	for i = placed + 1, POOL_SIZE do layers[i]:Hide(); layers[i].icon = nil end
+end
+
+local function schedule()
+	-- Nothing to do in combat (layers are hidden by the state driver, refresh() bails), so don't
+	-- even spin a timer — UNIT_AURA fires constantly mid-fight. PLAYER_REGEN_ENABLED re-maps after.
+	if( scheduled or InCombatLockdown() ) then return end
+	scheduled = true
+	C_Timer.After(0.05, function() scheduled = false; refresh() end)
+end
+
+eventFrame = CreateFrame("Frame")
+eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")     -- re-map once combat ends
+eventFrame:RegisterUnitEvent("UNIT_AURA", "player")
+eventFrame:SetScript("OnEvent", schedule)
+
+-- Re-map after SUF rebuilds/repositions its aura icons (config or layout changes).
+if( ShadowUF and ShadowUF.Layout ) then
+	hooksecurefunc(ShadowUF.Layout, "Reload", schedule)
+end

--- a/modules/auracancel.lua
+++ b/modules/auracancel.lua
@@ -71,7 +71,12 @@ local function refresh()
 					if( placed < POOL_SIZE and icon:IsShown() and icon.unit and icon.auraInstanceID
 						and icon.filter and icon.filter:find("HELPFUL") and UnitIsUnit(icon.unit, "player") ) then
 						local data = C_UnitAuras.GetAuraDataByAuraInstanceID("player", icon.auraInstanceID)
-						if( data and data.name and configureLayer(layers[placed + 1], icon, data.name) ) then
+						-- 12.0 secrets aura names in encounters (C_Secrets.ShouldAurasBeSecret, and it is
+						-- NOT combat-gated — a boss target alone flips it). Feeding a secret string to
+						-- SetAttribute taints SUF, so those buffs get no layer. Per-spell exempt auras
+						-- (GetSpellAuraSecrecy == 0) stay readable and still get one.
+						if( data and data.name and not issecretvalue(data.name)
+							and configureLayer(layers[placed + 1], icon, data.name) ) then
 							placed = placed + 1
 						end
 					end

--- a/modules/auracancel.lua
+++ b/modules/auracancel.lua
@@ -37,14 +37,23 @@ local function ensurePool()
 end
 
 -- Point a layer at a SUF aura icon (out of combat only) with a /cancelaura macro for its buff.
+-- Copies the icon's rect instead of anchoring to it: a protected frame anchored to the icon
+-- makes the icon's geometry protected too, so SUF's own in-combat aura re-layout
+-- (SetHeight/SetWidth/SetScale on the icons) would be blocked. Rect copies leave the icons free;
+-- refresh() re-syncs positions out of combat.
 local function configureLayer(layer, icon, name)
+	local left, bottom = icon:GetLeft(), icon:GetBottom()
+	if( not left ) then return false end -- no rect yet
 	layer.icon = icon
 	layer:SetAttribute("type", "macro")
 	layer:SetAttribute("macrotext", "/cancelaura " .. name)
+	local scale = icon:GetEffectiveScale() / layer:GetEffectiveScale()
 	layer:ClearAllPoints()
-	layer:SetAllPoints(icon)
+	layer:SetPoint("BOTTOMLEFT", UIParent, "BOTTOMLEFT", left * scale, bottom * scale)
+	layer:SetSize(icon:GetWidth() * scale, icon:GetHeight() * scale)
 	layer:SetFrameLevel(icon:GetFrameLevel() + 10)
 	layer:Show()
+	return true
 end
 
 -- Cover every shown, cancelable player-buff icon with a secure layer (out of combat).
@@ -62,9 +71,8 @@ local function refresh()
 					if( placed < POOL_SIZE and icon:IsShown() and icon.unit and icon.auraInstanceID
 						and icon.filter and icon.filter:find("HELPFUL") and UnitIsUnit(icon.unit, "player") ) then
 						local data = C_UnitAuras.GetAuraDataByAuraInstanceID("player", icon.auraInstanceID)
-						if( data and data.name ) then
+						if( data and data.name and configureLayer(layers[placed + 1], icon, data.name) ) then
 							placed = placed + 1
-							configureLayer(layers[placed], icon, data.name)
 						end
 					end
 				end

--- a/modules/auras.lua
+++ b/modules/auras.lua
@@ -438,20 +438,6 @@ local function hideTooltip(self)
 	end
 end
 
-local function cancelAura(self, mouseButton)
-	if( mouseButton ~= "RightButton" ) then return end
-	if( InCombatLockdown() ) then return end
-	if( not self.filter or not self.filter:find("HELPFUL") ) then return end
-	if( not self.unit or not UnitIsUnit(self.unit, "player") ) then return end
-	
-	if( self.auraInstanceID ) then
-		local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID("player", self.auraInstanceID)
-		if( auraData and auraData.name ) then
-			CancelSpellByName(auraData.name)
-		end
-	end
-end
-
 local function updateButton(id, group, config)
 	local button = group.buttons[id]
 	if( not button ) then
@@ -460,7 +446,6 @@ local function updateButton(id, group, config)
 		button = group.buttons[id]
 		button:SetScript("OnEnter", showTooltip)
 		button:SetScript("OnLeave", hideTooltip)
-		button:RegisterForClicks("RightButtonUp")
 
 		button.cooldown = CreateFrame("Cooldown", group.parent:GetName() .. "Aura" .. group.type .. id .. "Cooldown", button, "CooldownFrameTemplate")
 		button.cooldown:SetAllPoints(button)
@@ -514,11 +499,6 @@ local function updateButton(id, group, config)
 		button:SetMouseClickEnabled(not config.clickThrough)
 	end
 
-	if not config.clickThrough then
-		button:SetScript("OnClick", cancelAura)
-	else
-		button:SetScript("OnClick", nil)
-	end
 	button.parent = group.parent
 	button:ClearAllPoints()
 	button:Hide()


### PR DESCRIPTION
Adds right-click/click-to-cancel for the player's own buffs, without giving up SUF's aura filtering/layout.

## The problem
Blizzard restricts buff cancellation to **secure**, hardware-triggered code. SUF's aura icons are intentionally **insecure** (so SUF can filter, lay out multiple aura frames, and rebuild icons every frame — including in combat, which a protected frame can't do). So the icons themselves can't be made to cancel on click, and the old `cancelAura` (`CancelSpellByName` from an insecure `OnClick`) was silently blocked and never worked.

## The approach
Leave SUF's icons exactly as they are, and lay a pool of **invisible `SecureActionButton` layers** over the cancelable player-buff icons out of combat, each carrying a `/cancelaura <name>` macro. Key details:

- The pool lives in a container hidden in combat by a **secure state driver** (`RegisterStateDriver(container, "visibility", "[combat] hide; show")`), so the secure layers are never shown/hidden from Lua during combat — **taint-free**. SUF's icons revert to normal in combat.
- Layers **copy their icon's rect** (UIParent-relative, scale-corrected) at refresh time rather than anchoring to it. Anchoring a protected frame to an icon makes the icon's geometry protected too, which would block SUF's own in-combat aura re-layout (`SetHeight`/`SetWidth`/`SetScale` on every `UNIT_AURA`) with ADDON_ACTION_BLOCKED. Rect copies leave SUF's icons completely untouched; the existing refresh paths re-sync positions out of combat.
- Hover is forwarded to the icon beneath, so SUF's aura tooltip still shows through.
- Re-mapped on `UNIT_AURA` / combat-end / `ShadowUF.Layout:Reload`, throttled, and skipped entirely in combat.
- Respects each aura frame's click-through setting; only shown, cancelable player buffs get a layer.

Out-of-combat only (secure attributes/anchors can't change in combat — same reason the default frames can't cancel most buffs mid-fight). Debuffs on yourself aren't cancelable, so only buffs get layers.

Also removes the dead `cancelAura`/`CancelSpellByName` path it supersedes.

New file `modules/auracancel.lua` + one TOC line; the only change to `auras.lua` is deleting the old broken cancel. Approach adapted from the JustAC addon's precombat click overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
