### PR TITLE
Don't hide aura tooltips with the 'Hide tooltips in combat' option

### DIFF
--- a/modules/auras.lua
+++ b/modules/auras.lua
@@ -412,7 +412,6 @@ end
 local function showTooltip(self)
 	if( not ShadowUF.db.profile.locked ) then return end
 	if( GameTooltip:IsForbidden() ) then return end
-	if( ShadowUF.db.profile.tooltipCombat and InCombatLockdown() ) then return end
 
 	GameTooltip:SetOwner(self, "ANCHOR_BOTTOMLEFT")
 	if( self.filter == "TEMP" ) then


### PR DESCRIPTION
The "Hide tooltips in combat" option is documented as *"Prevents unit tooltips from showing while in combat."*, but it also suppressed buff/debuff tooltips on the aura icons.

Aura tooltips are the ones most useful mid-fight (checking what a debuff is doing to you), and showing `GameTooltip` in combat is not a protected action, so there's no secure/taint reason to block them. This removes the combat gate from `showTooltip` in `modules/auras.lua`; unit frame tooltips are still hidden in combat by the option via `modules/units.lua`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)