### PR TITLE
Aura cooldown useParentLevel to improve pandemic overlay

### DIFF
--- a/ShadowedUnitFrames.xml
+++ b/ShadowedUnitFrames.xml
@@ -5,4 +5,5 @@
 			<Attribute name="_onstate-vehicleui" type="string" value="local unit = self:GetAttribute('unit'); if unit and newstate == 'vehicle' and UnitPlayerOrPetInRaid(unit) and not UnitTargetsVehicleInRaidUI(unit) then self:SetAttribute('toggleForVehicle', false) else self:SetAttribute('toggleForVehicle', true) end" />
 		</Attributes>
 	</Button>
+	<Cooldown name="SUF_AuraCooldownTemplate" virtual="true" inherits="CooldownFrameTemplate" useParentLevel="true"/>
 </Ui>

--- a/modules/auraindicators.lua
+++ b/modules/auraindicators.lua
@@ -593,7 +593,7 @@ local function makeIndicatorSlotStyler(display, isHarmful)
 		end
 
 		if( display.duration ) then
-			local cooldown = CreateFrame("Cooldown", nil, button, "CooldownFrameTemplate")
+			local cooldown = CreateFrame("Cooldown", nil, button, "SUF_AuraCooldownTemplate")
 			cooldown:SetAllPoints(button)
 			cooldown:SetReverse(true)
 			cooldown:SetHideCountdownNumbers(true)

--- a/modules/auras.lua
+++ b/modules/auras.lua
@@ -111,10 +111,12 @@ end
 
 -- Overlay on the icon, pulsing between zero and the configured alpha
 -- Shown while the aura sits in its pandemic window
+-- OVERLAY sublevel 3 sits above the border (0), dispel border (1) and dispel icon (2), and above the cooldown swipe
+-- now that the aura cooldown shares the button's frame level (see SUF_AuraCooldownTemplate)
 function Auras:CreatePandemicOverlay(button, layer, sublevel)
 	local color = ShadowUF.db.profile.auraColors.pandemic
 
-	local overlay = button:CreateTexture(nil, layer or "ARTWORK", nil, sublevel)
+	local overlay = button:CreateTexture(nil, layer or "OVERLAY", nil, sublevel or 3)
 	overlay:SetAllPoints(button)
 	overlay:SetColorTexture(color and color.r or 1, color and color.g or 1, color and color.b or 1, color and color.a or 0.35)
 
@@ -417,7 +419,7 @@ local function updateButton(id, group, config)
 
 		button = group.buttons[id]
 
-		button.cooldown = CreateFrame("Cooldown", nil, button, "CooldownFrameTemplate")
+		button.cooldown = CreateFrame("Cooldown", nil, button, "SUF_AuraCooldownTemplate")
 		button.cooldown:SetAllPoints(button)
 		button.cooldown:SetReverse(true)
 		button.cooldown:SetDrawEdge(false)
@@ -852,7 +854,7 @@ local function makeButtonInitializer(group, config, section, sectionIndex)
 			pcall(button.AddPandemicRegion, button, pandemic)
 		end
 
-		local cooldown = CreateFrame("Cooldown", nil, button, "CooldownFrameTemplate")
+		local cooldown = CreateFrame("Cooldown", nil, button, "SUF_AuraCooldownTemplate")
 		cooldown:SetAllPoints(button)
 		cooldown:SetReverse(true)
 		cooldown:SetDrawEdge(false)
@@ -1714,7 +1716,7 @@ function Auras:ShowBossDebuffsPlaceholders(frame)
 			-- Same structure as updateButton: icon, border, cooldown, stack
 			button = CreateFrame("Button", nil, container)
 
-			button.cooldown = CreateFrame("Cooldown", nil, button, "CooldownFrameTemplate")
+			button.cooldown = CreateFrame("Cooldown", nil, button, "SUF_AuraCooldownTemplate")
 			button.cooldown:SetAllPoints(button)
 			button.cooldown:SetReverse(true)
 			button.cooldown:SetDrawEdge(false)


### PR DESCRIPTION
The pandemic overlay can be really hard to see since it's behind the cooldown swipe.

Before: https://imgur.com/a/vxs5MsV
After: https://imgur.com/a/Ojb7VEc

This change is a bit wide-reaching but I haven't noticed any issues.

I also want to do some follow-ups to make it more usable:
- Make it a per-group setting, rather than global. For example, right now it shows up on a Gaze of the Alnseer buff. As a DPS I only want the pandemic overlay on debuffs on target/focus/boss frame.
- Related to the above, per-group allow it to be selected for my auras ("PLAYER") only, similar to "enlarge my auras". Right now, I see it on all target debuffs, even other players' DoTs.
- Add a color curve for the cooldown timer text as well. There is way to make it percentage duration, but not sure if it will be fully consistent with the true pandemic range.