### PR TITLE
- Changed: channel cast no longer leaks castID into the global namespace

### DIFF
--- a/modules/cast.lua
+++ b/modules/cast.lua
@@ -354,7 +354,9 @@ function Cast:UpdateCurrentCast(frame)
 		self:UpdateCast(frame, frame.unitSUF, false, name, text, texture, startTime, endTime, isTradeSkill, notInterruptible, spellID, castID)
 	elseif( UnitChannelInfo(frame.unitSUF) ) then
 		local name, text, texture, startTime, endTime, isTradeSkill, notInterruptible, spellID, _, _, castBarID = UnitChannelInfo(frame.unitSUF)
-		castID = castBarID or spellID
+		-- UnitChannelInfo returns no castID, so unlike the casting branch above there is no local of that
+		-- name in scope here and this used to write a global on every channel update
+		local castID = castBarID or spellID
 		self:UpdateCast(frame, frame.unitSUF, true, name, text, texture, startTime, endTime, isTradeSkill, notInterruptible, spellID, castID)
 	else
 		if( ShadowUF.db.profile.units[frame.unitType].castBar.autoHide ) then


### PR DESCRIPTION
Stop the channel branch writing castID to the global namespace

UnitChannelInfo does not return a castID, so unlike the casting branch above it there was no local of that name in scope and the assignment created a global. It worked, because the value is read on the very next line, but every channel update wrote to _G.